### PR TITLE
Add direct dependencies on MP-OT and OT

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -11,6 +11,15 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.microprofile.opentracing</groupId>
+      <artifactId>microprofile-opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-jaxrs2</artifactId>
       <version>${verion.opentracing.jaxrs}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,27 @@
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.microprofile.opentracing</groupId>
+        <artifactId>microprofile-opentracing-api</artifactId>
+        <version>${version.microprofile.opentracing}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.microprofile.opentracing</groupId>
+        <artifactId>microprofile-opentracing-tck</artifactId>
+        <version>${version.microprofile.opentracing}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-api</artifactId>
+        <version>${version.opentracing}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-mock</artifactId>
+        <version>${version.opentracing}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
         <version>${version.arquillian}</version>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -18,12 +18,10 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-tck</artifactId>
-      <version>${version.microprofile.opentracing}</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
-      <version>${version.opentracing}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolves #15 

It also adds a direct dependency on opentracing-api because the tracer interface is used in the impl.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>