### PR TITLE
Fix NPE in CDI interceptor

### DIFF
--- a/implementation/src/main/java/io/smallrye/opentracing/SmallRyeTracingCDIInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/opentracing/SmallRyeTracingCDIInterceptor.java
@@ -62,7 +62,7 @@ public class SmallRyeTracingCDIInterceptor {
     if (methodTraced != null) {
       return methodTraced.value();
     }
-    return classTraced.value();
+    return classTraced != null ? classTraced.value() : false;
   }
 
   /**


### PR DESCRIPTION
Resolves #17 

NPE happened if traced annotation was not on class or method.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>