### PR TITLE
Mark the interceptor as bean, so that it can be referred by external modules

### DIFF
--- a/implementation/src/main/java/io/smallrye/opentracing/SmallRyeTracingCDIInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/opentracing/SmallRyeTracingCDIInterceptor.java
@@ -2,14 +2,16 @@ package io.smallrye.opentracing;
 
 import io.opentracing.Scope;
 import io.opentracing.Tracer;
-import java.lang.reflect.Method;
+import org.eclipse.microprofile.opentracing.Traced;
+
 import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.ws.rs.Path;
-import org.eclipse.microprofile.opentracing.Traced;
+import java.lang.reflect.Method;
 
 /**
  * @author Pavol Loffay
@@ -17,6 +19,7 @@ import org.eclipse.microprofile.opentracing.Traced;
 @Traced
 @Interceptor
 @Priority(value = Interceptor.Priority.LIBRARY_BEFORE + 1)
+@Dependent
 public class SmallRyeTracingCDIInterceptor {
 
   @Inject


### PR DESCRIPTION
With this change, it's not required to use a CDI Extension to register the interceptor. Having it on a beans.xml between the actual deployment and the interceptor is enough.

Tested this on a jboss-module JAR with a META-INF/beans.xml referring to the interceptor and adding the module as a dependency to the deployment.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>