### PR TITLE
Exclude javaee APIs from ot.contrib.interceptors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <version.opentracing>0.31.0</version.opentracing>
     <version.opentracing.jaxrs>0.3.1</version.opentracing.jaxrs>
     <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
-    <version.javax.ws.rs-api>2.0</version.javax.ws.rs-api>
+    <version.javax.ws.rs-api>2.1</version.javax.ws.rs-api>
     <version.resteasy>3.6.2.Final</version.resteasy>
     <version.weld>2.4.7.Final</version.weld>
     <version.wildfly>13.0.0.Final</version.wildfly>
@@ -85,6 +85,12 @@
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-interceptors</artifactId>
         <version>${version.opentracing.interceptors}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Resolves #46 

It was causing NoSuchFieldError: SERVER_SENT_EVENTS_TYPE, due to
resolving old jaxrs version at runtime.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>