### PR TITLE
Fixes #134: SmallRyeRestClientListener should not require CDI

### DIFF
--- a/implementation/src/main/java/io/smallrye/opentracing/SmallRyeRestClientListener.java
+++ b/implementation/src/main/java/io/smallrye/opentracing/SmallRyeRestClientListener.java
@@ -1,12 +1,11 @@
 package io.smallrye.opentracing;
 
-import javax.enterprise.inject.spi.CDI;
-
 import org.eclipse.microprofile.opentracing.Traced;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 
 /**
  * @author Pavol Loffay
@@ -21,7 +20,7 @@ public class SmallRyeRestClientListener implements RestClientListener {
             return;
         }
 
-        Tracer tracer = CDI.current().select(Tracer.class).get();
+        Tracer tracer = GlobalTracer.get();
         restClientBuilder.register(new SmallRyeClientTracingFeature(tracer));
         restClientBuilder.register(new OpenTracingAsyncInterceptorFactory(tracer));
     }

--- a/tck/src/test/java/io/smallrye/opentracing/TracerProducer.java
+++ b/tck/src/test/java/io/smallrye/opentracing/TracerProducer.java
@@ -7,6 +7,7 @@ import javax.inject.Singleton;
 
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
 
 /**
  * @author Pavol Loffay
@@ -18,6 +19,8 @@ public class TracerProducer {
     @Produces
     @Singleton
     public Tracer tracer() {
-        return new MockTracer();
+        MockTracer tracer = new MockTracer();
+        GlobalTracer.register(tracer);
+        return tracer;
     }
 }


### PR DESCRIPTION
Resolves #134 


According to the MicroProfile specification the `RestClientBuilder` should also be functional in a non-CDI environment and thus `SmallRyeRestClientListener` should not use CDI to retrieve the `Tracer` but `GlobalTracer#get()`.