### PR TITLE
avoid propagating "null" spans in RestClient integration

### DIFF
--- a/implementation/src/main/java/io/smallrye/opentracing/OpenTracingAsyncInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/opentracing/OpenTracingAsyncInterceptor.java
@@ -34,11 +34,15 @@ public class OpenTracingAsyncInterceptor implements AsyncInvocationInterceptor {
             countDownLatch.await();
         } catch (InterruptedException e) {
         }
-        scope = tracer.scopeManager().activate(span);
+        if (span != null) {
+            scope = tracer.scopeManager().activate(span);
+        }
     }
 
     @Override
     public void removeContext() {
-        scope.close();
+        if (scope != null) {
+            scope.close();
+        }
     }
 }


### PR DESCRIPTION
If the original RestClient invocation thread doesn't have an active
span, we shouldn't try to activate a `null` span on the RestClient
async thread.